### PR TITLE
chore: :arrow_up: change repository name of dependency to awarefy

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   args: ^2.0.0
   pointycastle_pc335:
     git:
-      url: https://github.com/hakali/pc-dart.git
+      url: https://github.com/awarefy/pc-dart.git
       ref: pc-335
 
 dev_dependencies:


### PR DESCRIPTION
Changed organization name to awarefy by changing company name.